### PR TITLE
ci: Handle unavailable Caddy versions and update version checking

### DIFF
--- a/.github/workflows/build-docker-image-alpine.yml
+++ b/.github/workflows/build-docker-image-alpine.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      
+
       - name: Set version if empty
         id: set_version
         run: |
@@ -46,18 +46,29 @@ jobs:
             echo "VERSION=${{ github.event.client_payload.latest_version }}" >> $GITHUB_ENV
           fi
 
+      - name: Check Caddy version availability
+        id: check_version
+        run: |
+          AVAILABLE=$(curl -sL https://hub.docker.com/v2/repositories/library/caddy/tags/${{ env.VERSION }}-alpine | jq -r '.name')
+          if [ "$AVAILABLE" != "${{ env.VERSION }}-alpine" ]; then
+            echo "Caddy version ${{ env.VERSION }}-alpine is not available. Exiting."
+            exit 1
+          fi
+
       - name: Build and push Docker image (alpine)
         uses: docker/build-push-action@v5
         with:
           context: .
           file: Dockerfile-alpine
           push: true
+          build-args: |
+            CADDY_VERSION=${{ env.VERSION }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le,linux/s390x
           tags: |
-            ghcr.io/${{ secrets.DOCKER_USERNAME }}/caddy-cloudflare-alpine:${{ env.VERSION }}
-            ghcr.io/${{ secrets.DOCKER_USERNAME }}/caddy-cloudflare-alpine:latest
-            ghcr.io/${{ secrets.DOCKER_USERNAME }}/caddy-cloudflare:${{ env.VERSION }}-alpine
-            ghcr.io/${{ secrets.DOCKER_USERNAME }}/caddy-cloudflare:alpine
+            ghcr.io/${{ github.repository_owner }}/caddy-cloudflare-alpine:${{ env.VERSION }}
+            ghcr.io/${{ github.repository_owner }}/caddy-cloudflare-alpine:latest
+            ghcr.io/${{ github.repository_owner }}/caddy-cloudflare:${{ env.VERSION }}-alpine
+            ghcr.io/${{ github.repository_owner }}/caddy-cloudflare:alpine
             ${{ secrets.DOCKERHUB_USERNAME }}/caddy-cloudflare-alpine:${{ env.VERSION }}
             ${{ secrets.DOCKERHUB_USERNAME }}/caddy-cloudflare-alpine:latest
             ${{ secrets.DOCKERHUB_USERNAME }}/caddy-cloudflare:${{ env.VERSION }}-alpine
@@ -65,8 +76,8 @@ jobs:
 
       - name: Clean up Docker images
         run: |
-          docker rmi ghcr.io/${{ secrets.DOCKER_USERNAME }}/caddy-cloudflare-alpine:${{ env.VERSION }} || true
-          docker rmi ghcr.io/${{ secrets.DOCKER_USERNAME }}/caddy-cloudflare:${{ env.VERSION }}-alpine || true
+          docker rmi ghcr.io/${{ github.repository_owner }}/caddy-cloudflare-alpine:${{ env.VERSION }} || true
+          docker rmi ghcr.io/${{ github.repository_owner }}/caddy-cloudflare:${{ env.VERSION }}-alpine || true
           docker rmi ${{ secrets.DOCKERHUB_USERNAME }}/caddy-cloudflare-alpine:${{ env.VERSION }} || true
           docker rmi ${{ secrets.DOCKERHUB_USERNAME }}/caddy-cloudflare:${{ env.VERSION }}-alpine || true
           docker builder prune --force
@@ -76,8 +87,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ env.VERSION }}-alpine
-          release_name: "Caddy Alpine Release ${{ env.VERSION }}-alpine"
+          tag_name: ${{ env.VERSION }}
+          release_name: "Caddy Release ${{ env.VERSION }}"
           body: "New Caddy release detected. See the full release notes [here](https://github.com/caddyserver/caddy/releases/tag/${{ env.VERSION }})."
           draft: false
           prerelease: false

--- a/.github/workflows/build-docker-image-standard.yml
+++ b/.github/workflows/build-docker-image-standard.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      
+
       - name: Set version if empty
         id: set_version
         run: |
@@ -46,22 +46,33 @@ jobs:
             echo "VERSION=${{ github.event.client_payload.latest_version }}" >> $GITHUB_ENV
           fi
 
+      - name: Check Caddy version availability
+        id: check_version
+        run: |
+          AVAILABLE=$(curl -sL https://hub.docker.com/v2/repositories/library/caddy/tags/${{ env.VERSION }} | jq -r '.name')
+          if [ "$AVAILABLE" != "${{ env.VERSION }}" ]; then
+            echo "Caddy version ${{ env.VERSION }} is not available. Exiting."
+            exit 1
+          fi
+
       - name: Build and push Docker image (standard)
         uses: docker/build-push-action@v5
         with:
           context: .
           file: Dockerfile
           push: true
+          build-args: |
+            CADDY_VERSION=${{ env.VERSION }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le,linux/s390x
           tags: |
-            ghcr.io/${{ secrets.DOCKER_USERNAME }}/caddy-cloudflare:${{ env.VERSION }}
-            ghcr.io/${{ secrets.DOCKER_USERNAME }}/caddy-cloudflare:latest
+            ghcr.io/${{ github.repository_owner }}/caddy-cloudflare:${{ env.VERSION }}
+            ghcr.io/${{ github.repository_owner }}/caddy-cloudflare:latest
             ${{ secrets.DOCKERHUB_USERNAME }}/caddy-cloudflare:${{ env.VERSION }}
             ${{ secrets.DOCKERHUB_USERNAME }}/caddy-cloudflare:latest
 
       - name: Clean up Docker images
         run: |
-          docker rmi ghcr.io/${{ secrets.DOCKER_USERNAME }}/caddy-cloudflare:${{ env.VERSION }} || true
+          docker rmi ghcr.io/${{ github.repository_owner }}/caddy-cloudflare:${{ env.VERSION }} || true
           docker rmi ${{ secrets.DOCKERHUB_USERNAME }}/caddy-cloudflare:${{ env.VERSION }} || true
           docker builder prune --force
 


### PR DESCRIPTION
Added checks for Caddy version availability before building. Ensure the correct Caddy version is used during builds by reading from version.json. Handle cases where the version payload is empty.

Closes #7 