### PR TITLE
docs: added troubleshooting note for dns challange configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ To configure the [ACME DNS challenge](https://caddyserver.com/docs/automatic-htt
 ```
 This configuration sets up the provider to use the Cloudflare DNS module with the API token provided as an environment variable. It ensures that your Caddy server can automatically issue and renew SSL certificates using DNS-01 challenges via Cloudflare.
 
-This setup is the same as specsifying the provider in the [tls directive's ACME issuer](https://caddyserver.com/docs/caddyfile/directives/tls#acme) configuration.
+This setup is the same as specifying the provider in the [tls directive's ACME issuer](https://caddyserver.com/docs/caddyfile/directives/tls#acme) configuration.
 
 [Sample Caddyfile](#sample-caddyfile)
 

--- a/README.md
+++ b/README.md
@@ -232,9 +232,22 @@ To configure the [ACME DNS challenge](https://caddyserver.com/docs/automatic-htt
 ```
 This configuration sets up the provider to use the Cloudflare DNS module with the API token provided as an environment variable. It ensures that your Caddy server can automatically issue and renew SSL certificates using DNS-01 challenges via Cloudflare.
 
-This setup is the same as specifying the provider in the [tls directive's ACME issuer](https://caddyserver.com/docs/caddyfile/directives/tls#acme) configuration.
+This setup is the same as specsifying the provider in the [tls directive's ACME issuer](https://caddyserver.com/docs/caddyfile/directives/tls#acme) configuration.
 
 [Sample Caddyfile](#sample-caddyfile)
+
+#### Troubleshooting
+
+You may encounter `solving challenges: presenting for challenge: adding temporary record for zone xyz.: got error status: HTTP 403.` 
+In such cases, try setting custom DNS resolvers like below to bypass resolver issues:
+```
+tls {
+  dns cloudflare {env.CF_API_TOKEN}
+  resolvers 1.1.1.1
+}
+```
+
+[Official troubleshooting guide](https://github.com/caddy-dns/cloudflare?tab=readme-ov-file#troubleshooting)
 
 ## Tags
 


### PR DESCRIPTION
Adds a troubleshooting note for DNS challenge configuration when using Caddy with Cloudflare. This documents a workaround using custom DNS resolvers to avoid 403 errors related to TXT record creation, especially in Docker environments.

### Changes
- Updated the documentation under the ACME DNS challenge section
- Added an example using `resolvers 1.1.1.1` inside the `tls` block

### Benefits
- Helps users encountering 403 errors during certificate issuance via DNS challenge
- Provides a clear fix for resolver-related issues when running Caddy inside Docker