### PR TITLE
fix: use env vars for DockerHub secrets to support conditional logic

### DIFF
--- a/.github/workflows/build-docker-image-alpine.yml
+++ b/.github/workflows/build-docker-image-alpine.yml
@@ -42,7 +42,10 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-        if: ${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' }}
+        env:
+          user: ${{ secrets.DOCKERHUB_USERNAME }}
+          token: ${{ secrets.DOCKERHUB_TOKEN }}
+        if: ${{ env.user != '' && env.token != '' }}
 
       - name: Convert Repository Owner to Lowercase
         run: |

--- a/.github/workflows/build-docker-image-standard.yml
+++ b/.github/workflows/build-docker-image-standard.yml
@@ -43,7 +43,10 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-        if: ${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' }}
+        env:
+          user: ${{ secrets.DOCKERHUB_USERNAME }}
+          token: ${{ secrets.DOCKERHUB_TOKEN }}
+        if: ${{ env.user != '' && env.token != '' }}
 
       - name: Convert Repository Owner to Lowercase
         run: |


### PR DESCRIPTION
Secrets cannot be directly referenced in if: conditionals.
#see https://docs.github.com/es/actions/writing-workflows/workflow-syntax-for-github-actions#example-using-secrets